### PR TITLE
Stricter node compatibility

### DIFF
--- a/templates/react/app/package.json
+++ b/templates/react/app/package.json
@@ -2,6 +2,9 @@
   "name": "pact-blank-app",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=12.13.0"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/templates/react/app/package.json
+++ b/templates/react/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=12.13.0"
+    "node": "^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",

--- a/templates/react/app/src/App.js
+++ b/templates/react/app/src/App.js
@@ -74,7 +74,7 @@ const App = () => {
         },
         kadenaAPI.meta.host
       );
-      const all = res.result.data;
+      const { data: all = [] } = res.result || {};
       //sorts memories by least recent
       all.sort((a, b) => a["block-height"].int - b["block-height"].int);
       setMemories(all);

--- a/templates/react/app/src/App.js
+++ b/templates/react/app/src/App.js
@@ -271,21 +271,22 @@ const App = () => {
     );
   };
 
-  const txFailure = () => {
-    return (
-      <Message style={{ fontSize: 20 }}>
-        <Message.Header style={{ marginBottom: 10 }}>
-          ERROR! INVESTIGATE BELOW
-        </Message.Header>
-        <p>{JSON.stringify(tx)}</p>
-        <p>
-          <a href={`${kadenaAPI.explorerURL}/tx/${tx.reqKey}`}>
-            View transaction in Block Explorer
-          </a>
-        </p>
-      </Message>
-    );
-  };
+  // Example error message:
+  // const txFailure = () => {
+  //   return (
+  //     <Message style={{ fontSize: 20 }}>
+  //       <Message.Header style={{ marginBottom: 10 }}>
+  //         ERROR! INVESTIGATE BELOW
+  //       </Message.Header>
+  //       <p>{JSON.stringify(tx)}</p>
+  //       <p>
+  //         <a href={`${kadenaAPI.explorerURL}/tx/${tx.reqKey}`}>
+  //           View transaction in Block Explorer
+  //         </a>
+  //       </p>
+  //     </Message>
+  //   );
+  // };
 
   const txValidationError = () => {
     return (
@@ -328,7 +329,7 @@ const App = () => {
       <Segment raised padded="very">
         <div style={{ margin: 30 }}>
           <h1>
-            <a>Welcome to the Kadena Memory Wall</a>
+            Welcome to the Kadena Memory Wall
           </h1>
 
           <h2>Smart Contract Details:</h2>


### PR DESCRIPTION
I'd normally put these in a few separate PR's but not sure how closely this is being monitored/reviewed etc. I recently tried setting this up and had a few small issues. 

### 1. Node version
The steps to get this running are basically:
1. download create pact app:`npm i -g create-pact-app`
2. run `create-pact-app`
3. This will ask you to install dependencies of the app

So with node `v13.17`, I ran all 3 steps, then hit an error on step 3:
```
error pretty-format@27.2.2: The engine "node" is incompatible with this module. Expected version "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0". Got "13.7.0"
```

As this happens after you've already downloaded create-pact app, you then have to get your new version of node and go back to step 1 as `npm i -g create-pact-app` will download the proj in e.g. `Users/blahblah/.nvm/versions/node/v13.17.0/bin/create-pact-app`

I then downgraded to `10.13`, ran through the 3 steps again, then got the error:
```
@testing-library/dom@8.6.0: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.13.0"
```
So then had to change node version again, this time to `12.13` and go through the steps again, then it was all good.

So to make this a nicer experience getting set up, I've added the `engines` flag in the package.json of the react template, to force matching the upper bounds of what the initial pretty-format package requires. This will limit users of create-pact-app getting this wrong in future.

### 2. Webpack warnings
<img width="712" alt="Screenshot 2021-10-21 at 21 57 02" src="https://user-images.githubusercontent.com/7824235/138359119-b23518af-c92b-4c9d-a10b-3d1dd866621d.png">

Couple of simple warnings based on some react errors. I've just cleaned them up so the output in the terminal is clean e.g.:
<img width="495" alt="Screenshot 2021-10-21 at 22 27 20" src="https://user-images.githubusercontent.com/7824235/138359253-7936c496-f163-4400-bc24-e821acd3eb84.png">

### 3. Running the app
When I ran the app it failed to build with an error:
<img width="1052" alt="Screenshot 2021-10-21 at 21 51 33" src="https://user-images.githubusercontent.com/7824235/138359464-f8c7aed2-1bcb-4e5d-ad68-faf36d62f1c7.png">

I've added a bit of a safer check to stop the app crashing. This doesn't actually fix any functionality, but does make for a nicer experience on load.
